### PR TITLE
Create 3d flipbook wordpress plugin

### DIFF
--- a/wp-content/plugins/wp-3d-flipbook/assets/css/admin.css
+++ b/wp-content/plugins/wp-3d-flipbook/assets/css/admin.css
@@ -1,0 +1,6 @@
+/* Admin styles for WP 3D Flipbook */
+.wp3dfb-metabox .wp3dfb-pages { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: 8px; }
+.wp3dfb-metabox .wp3dfb-page { width: 100px; height: 100px; border: 1px solid #ccd0d4; background: #fff; position: relative; display: flex; align-items: center; justify-content: center; }
+.wp3dfb-metabox .wp3dfb-page img { max-width: 100%; max-height: 100%; }
+.wp3dfb-metabox .wp3dfb-remove { position: absolute; right: 2px; top: 2px; padding: 0 6px; line-height: 1.2; }
+.wp3dfb-placeholder { width: 100px; height: 100px; background: #f3f4f5; border: 1px dashed #ccd0d4; }

--- a/wp-content/plugins/wp-3d-flipbook/assets/css/frontend.css
+++ b/wp-content/plugins/wp-3d-flipbook/assets/css/frontend.css
@@ -1,0 +1,3 @@
+/* Frontend styles for WP 3D Flipbook */
+.wp3dfb-viewer { position: relative; }
+.wp3dfb-canvas { width: 100%; height: 100%; }

--- a/wp-content/plugins/wp-3d-flipbook/assets/js/admin.js
+++ b/wp-content/plugins/wp-3d-flipbook/assets/js/admin.js
@@ -1,0 +1,51 @@
+(function($){
+	var frame;
+
+	function renderItem(attachment){
+		var id = attachment.id || attachment.get('id');
+		var url = (attachment.sizes && attachment.sizes.thumbnail && attachment.sizes.thumbnail.url) || attachment.url || (attachment.get && attachment.get('url')) || '';
+		var $li = $('<li class="wp3dfb-page"/>').attr('data-id', id);
+		$li.append('<input type="hidden" name="wp3dfb_pages[]" value="'+ id +'" />');
+		$li.append('<img alt="" />').find('img').attr('src', url);
+		$li.append('<button type="button" class="button link-button wp3dfb-remove">&times;</button>');
+		return $li;
+	}
+
+	function openFrame(){
+		if (frame) { frame.open(); return; }
+		frame = wp.media({
+			title: 'Select Flipbook Pages',
+			button: { text: 'Add to Flipbook' },
+			multiple: true,
+			library: { type: 'image' }
+		});
+		frame.on('select', function(){
+			var selection = frame.state().get('selection');
+			if (!selection) return;
+			var $list = $('#wp3dfb-pages-list');
+			selection.each(function(attachment){
+				attachment = attachment.toJSON ? attachment.toJSON() : attachment;
+				$list.append(renderItem(attachment));
+			});
+		});
+		frame.open();
+	}
+
+	function bindEvents(){
+		$(document).on('click', '#wp3dfb-add-pages', function(){
+			openFrame();
+		});
+		$(document).on('click', '.wp3dfb-remove', function(){
+			$(this).closest('.wp3dfb-page').remove();
+		});
+		$('#wp3dfb-pages-list').sortable({
+			items: '> li.wp3dfb-page',
+			placeholder: 'wp3dfb-placeholder',
+			forcePlaceholderSize: true
+		});
+	}
+
+	$(function(){
+		bindEvents();
+	});
+})(jQuery);

--- a/wp-content/plugins/wp-3d-flipbook/assets/js/frontend.js
+++ b/wp-content/plugins/wp-3d-flipbook/assets/js/frontend.js
@@ -1,0 +1,40 @@
+(function(){
+	function getPageFlipCtor() {
+		if (window.PageFlip) return window.PageFlip;
+		if (window.pageFlip) return window.pageFlip;
+		if (window.St && window.St.PageFlip) return window.St.PageFlip;
+		return null;
+	}
+
+	function initAll() {
+		var PageFlipCtor = getPageFlipCtor();
+		if (!PageFlipCtor) { return; }
+		var viewers = document.querySelectorAll('.wp3dfb-viewer');
+		viewers.forEach(function(container){
+			try {
+				var pages = [];
+				try { pages = JSON.parse(container.getAttribute('data-pages') || '[]'); } catch(e) { pages = []; }
+				var width = parseInt(container.getAttribute('data-width') || '800', 10);
+				var height = parseInt(container.getAttribute('data-height') || '600', 10);
+				if (!pages || !pages.length) return;
+
+				var instance = new PageFlipCtor(container, {
+					width: width,
+					height: height,
+					showCover: false,
+					maxShadowOpacity: 0.5,
+					mobileScrollSupport: true
+				});
+				instance.loadFromImages(pages);
+			} catch (err) {
+				// swallow errors silently
+			}
+		});
+	}
+
+	if (document.readyState === 'complete' || document.readyState === 'interactive') {
+		setTimeout(initAll, 0);
+	} else {
+		document.addEventListener('DOMContentLoaded', initAll);
+	}
+})();

--- a/wp-content/plugins/wp-3d-flipbook/includes/admin-metabox.php
+++ b/wp-content/plugins/wp-3d-flipbook/includes/admin-metabox.php
@@ -1,0 +1,60 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+function wp3dfb_register_metabox() {
+	add_meta_box(
+		'wp3dfb_pages_box',
+		__( 'Flipbook Pages', 'wp-3d-flipbook' ),
+		'wp3dfb_render_metabox',
+		'wp3dfb_flipbook',
+		'normal',
+		'default'
+	);
+}
+
+function wp3dfb_render_metabox( $post ) {
+	wp_nonce_field( 'wp3dfb_save_pages', 'wp3dfb_nonce' );
+	$pages = get_post_meta( $post->ID, '_wp3dfb_pages', true );
+	$pages = is_array( $pages ) ? array_map( 'absint', $pages ) : array();
+	?>
+	<div class="wp3dfb-metabox">
+		<p><?php esc_html_e( 'Add images as pages. Drag to reorder.', 'wp-3d-flipbook' ); ?></p>
+		<ul id="wp3dfb-pages-list" class="wp3dfb-pages">
+			<?php foreach ( $pages as $attachment_id ) :
+				$url = wp_get_attachment_image_url( $attachment_id, 'thumbnail' );
+				?>
+				<li class="wp3dfb-page" data-id="<?php echo esc_attr( $attachment_id ); ?>">
+					<input type="hidden" name="wp3dfb_pages[]" value="<?php echo esc_attr( $attachment_id ); ?>" />
+					<img src="<?php echo esc_url( $url ); ?>" alt="" />
+					<button type="button" class="button link-button wp3dfb-remove">&times;</button>
+				</li>
+			<?php endforeach; ?>
+		</ul>
+		<p>
+			<button type="button" class="button button-primary" id="wp3dfb-add-pages"><?php esc_html_e( 'Add Pages', 'wp-3d-flipbook' ); ?></button>
+		</p>
+	</div>
+	<?php
+}
+
+function wp3dfb_save_metabox( $post_id ) {
+	if ( ! isset( $_POST['wp3dfb_nonce'] ) || ! wp_verify_nonce( $_POST['wp3dfb_nonce'], 'wp3dfb_save_pages' ) ) {
+		return;
+	}
+	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+		return;
+	}
+	if ( isset( $_POST['post_type'] ) && 'wp3dfb_flipbook' === $_POST['post_type'] ) {
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+	}
+
+	$pages = isset( $_POST['wp3dfb_pages'] ) && is_array( $_POST['wp3dfb_pages'] ) ? array_map( 'absint', $_POST['wp3dfb_pages'] ) : array();
+
+	if ( empty( $pages ) ) {
+		delete_post_meta( $post_id, '_wp3dfb_pages' );
+	} else {
+		update_post_meta( $post_id, '_wp3dfb_pages', array_values( $pages ) );
+	}
+}

--- a/wp-content/plugins/wp-3d-flipbook/includes/assets.php
+++ b/wp-content/plugins/wp-3d-flipbook/includes/assets.php
@@ -1,0 +1,24 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+function wp3dfb_admin_assets( $hook ) {
+	global $post_type;
+	if ( in_array( $hook, array( 'post-new.php', 'post.php' ), true ) && 'wp3dfb_flipbook' === $post_type ) {
+		wp_enqueue_media();
+		wp_enqueue_script( 'jquery-ui-sortable' );
+		wp_enqueue_style( 'wp3dfb-admin', WP3DFB_URL . 'assets/css/admin.css', array(), WP3DFB_VERSION );
+		wp_enqueue_script( 'wp3dfb-admin', WP3DFB_URL . 'assets/js/admin.js', array( 'jquery' ), WP3DFB_VERSION, true );
+	}
+}
+
+function wp3dfb_frontend_assets() {
+	// External PageFlip library (StPageFlip)
+	$cdn_js  = apply_filters( 'wp3dfb_cdn_js', 'https://cdn.jsdelivr.net/npm/page-flip@2.0.7/dist/js/page-flip.browser.min.js' );
+	$cdn_css = apply_filters( 'wp3dfb_cdn_css', 'https://cdn.jsdelivr.net/npm/page-flip@2.0.7/dist/css/page-flip.css' );
+
+	wp_register_style( 'page-flip', $cdn_css, array(), '2.0.7' );
+	wp_register_script( 'page-flip', $cdn_js, array(), '2.0.7', true );
+
+	wp_register_style( 'wp3dfb-frontend', WP3DFB_URL . 'assets/css/frontend.css', array( 'page-flip' ), WP3DFB_VERSION );
+	wp_register_script( 'wp3dfb-frontend', WP3DFB_URL . 'assets/js/frontend.js', array( 'page-flip' ), WP3DFB_VERSION, true );
+}

--- a/wp-content/plugins/wp-3d-flipbook/includes/cpt.php
+++ b/wp-content/plugins/wp-3d-flipbook/includes/cpt.php
@@ -1,0 +1,33 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+function wp3dfb_register_cpt() {
+	$labels = array(
+		'name'               => __( 'Flipbooks', 'wp-3d-flipbook' ),
+		'singular_name'      => __( 'Flipbook', 'wp-3d-flipbook' ),
+		'add_new'            => __( 'Add New', 'wp-3d-flipbook' ),
+		'add_new_item'       => __( 'Add New Flipbook', 'wp-3d-flipbook' ),
+		'edit_item'          => __( 'Edit Flipbook', 'wp-3d-flipbook' ),
+		'new_item'           => __( 'New Flipbook', 'wp-3d-flipbook' ),
+		'view_item'          => __( 'View Flipbook', 'wp-3d-flipbook' ),
+		'search_items'       => __( 'Search Flipbooks', 'wp-3d-flipbook' ),
+		'not_found'          => __( 'No flipbooks found', 'wp-3d-flipbook' ),
+		'not_found_in_trash' => __( 'No flipbooks found in Trash', 'wp-3d-flipbook' ),
+		'menu_name'          => __( '3D Flipbooks', 'wp-3d-flipbook' ),
+	);
+
+	$args = array(
+		'labels'             => $labels,
+		'public'             => false,
+		'show_ui'            => true,
+		'show_in_menu'       => true,
+		'show_in_rest'       => false,
+		'supports'           => array( 'title' ),
+		'menu_icon'          => 'dashicons-book',
+		'capability_type'    => 'post',
+		'has_archive'        => false,
+		'rewrite'            => false,
+	);
+
+	register_post_type( 'wp3dfb_flipbook', $args );
+}

--- a/wp-content/plugins/wp-3d-flipbook/includes/shortcode.php
+++ b/wp-content/plugins/wp-3d-flipbook/includes/shortcode.php
@@ -1,0 +1,48 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+function wp3dfb_shortcode( $atts ) {
+	$atts = shortcode_atts( array(
+		'id'     => 0,
+		'width'  => '800',
+		'height' => '600',
+	), $atts, 'wp3dfb' );
+
+	$post_id = absint( $atts['id'] );
+	if ( 0 === $post_id ) {
+		if ( is_singular( 'wp3dfb_flipbook' ) ) {
+			global $post;
+			$post_id = $post->ID;
+		} else {
+			return '';
+		}
+	}
+
+	$pages = get_post_meta( $post_id, '_wp3dfb_pages', true );
+	$pages = is_array( $pages ) ? array_map( 'absint', $pages ) : array();
+	if ( empty( $pages ) ) {
+		return '';
+	}
+
+	$image_urls = array();
+	foreach ( $pages as $attachment_id ) {
+		$url = wp_get_attachment_image_url( $attachment_id, 'full' );
+		if ( $url ) {
+			$image_urls[] = esc_url_raw( $url );
+		}
+	}
+	if ( empty( $image_urls ) ) {
+		return '';
+	}
+
+	$container_id = 'wp3dfb-' . $post_id . '-' . wp_generate_uuid4();
+
+	wp_enqueue_style( 'wp3dfb-frontend' );
+	wp_enqueue_script( 'wp3dfb-frontend' );
+
+	$style = sprintf( 'width:%dpx;height:%dpx;', (int) $atts['width'], (int) $atts['height'] );
+
+	$html  = '<div id="' . esc_attr( $container_id ) . '" class="wp3dfb-viewer" style="' . esc_attr( $style ) . '" data-width="' . esc_attr( (int) $atts['width'] ) . '" data-height="' . esc_attr( (int) $atts['height'] ) . '" data-pages="' . esc_attr( wp_json_encode( $image_urls ) ) . '"></div>';
+
+	return $html;
+}

--- a/wp-content/plugins/wp-3d-flipbook/index.php
+++ b/wp-content/plugins/wp-3d-flipbook/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/wp-content/plugins/wp-3d-flipbook/readme.txt
+++ b/wp-content/plugins/wp-3d-flipbook/readme.txt
@@ -1,0 +1,11 @@
+WP 3D Flipbook (Lite)
+
+Contributors: cursor-ai
+Requires at least: 5.8
+Tested up to: 6.6
+Requires PHP: 7.4
+Stable tag: 0.1.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+A lightweight 3D flipbook plugin with a custom post type and shortcode.

--- a/wp-content/plugins/wp-3d-flipbook/wp-3d-flipbook.php
+++ b/wp-content/plugins/wp-3d-flipbook/wp-3d-flipbook.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Plugin Name: WP 3D Flipbook (Lite)
+ * Description: A lightweight 3D flipbook plugin with a custom post type and shortcode.
+ * Version: 0.1.0
+ * Author: Cursor AI
+ * License: GPLv2 or later
+ * Text Domain: wp-3d-flipbook
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Plugin constants
+define( 'WP3DFB_VERSION', '0.1.0' );
+define( 'WP3DFB_FILE', __FILE__ );
+define( 'WP3DFB_DIR', plugin_dir_path( __FILE__ ) );
+define( 'WP3DFB_URL', plugin_dir_url( __FILE__ ) );
+
+// Includes
+require_once WP3DFB_DIR . 'includes/cpt.php';
+require_once WP3DFB_DIR . 'includes/assets.php';
+require_once WP3DFB_DIR . 'includes/admin-metabox.php';
+require_once WP3DFB_DIR . 'includes/shortcode.php';
+
+// Activation/Deactivation
+function wp3dfb_activate() {
+	// Register CPT first to ensure rewrite rules exist if needed
+	wp3dfb_register_cpt();
+	flush_rewrite_rules();
+}
+register_activation_hook( WP3DFB_FILE, 'wp3dfb_activate' );
+
+function wp3dfb_deactivate() {
+	flush_rewrite_rules();
+}
+register_deactivation_hook( WP3DFB_FILE, 'wp3dfb_deactivate' );
+
+// Bootstrap hooks
+add_action( 'init', 'wp3dfb_register_cpt' );
+add_action( 'add_meta_boxes', 'wp3dfb_register_metabox' );
+add_action( 'save_post', 'wp3dfb_save_metabox' );
+add_action( 'admin_enqueue_scripts', 'wp3dfb_admin_assets' );
+add_action( 'wp_enqueue_scripts', 'wp3dfb_frontend_assets' );
+
+// Shortcode
+add_shortcode( 'wp3dfb', 'wp3dfb_shortcode' );


### PR DESCRIPTION
Implement a basic WordPress 3D flipbook plugin with a custom post type, admin UI for image management, and a shortcode for frontend display.

---
<a href="https://cursor.com/background-agent?bcId=bc-fcfc22c7-d41c-46af-9d5f-fcef1bdc0bc7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fcfc22c7-d41c-46af-9d5f-fcef1bdc0bc7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

