### PR TITLE
Create 3d flipbook wordpress plugin

### DIFF
--- a/wp-3d-flipbook-lite/assets/admin/admin.css
+++ b/wp-3d-flipbook-lite/assets/admin/admin.css
@@ -1,0 +1,36 @@
+#wp3d-pages-wrapper {
+	margin-top: 8px;
+}
+#wp3d-pages-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+#wp3d-pages-list li.wp3d-page-item {
+	position: relative;
+	width: 96px;
+	height: 96px;
+	border: 1px solid #ccd0d4;
+	background: #fff;
+	padding: 2px;
+	box-sizing: border-box;
+	cursor: move;
+}
+#wp3d-pages-list li.wp3d-page-item img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	display: block;
+}
+#wp3d-pages-list .wp3d-remove {
+	position: absolute;
+	top: -8px;
+	right: -8px;
+	background: #fff;
+	border-radius: 50%;
+	box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+	cursor: pointer;
+}

--- a/wp-3d-flipbook-lite/assets/admin/admin.js
+++ b/wp-3d-flipbook-lite/assets/admin/admin.js
@@ -1,0 +1,57 @@
+(function($){
+  'use strict';
+
+  function refreshHiddenInput($list, $input) {
+    var ids = [];
+    $list.find('li.wp3d-page-item').each(function(){
+      var id = $(this).data('id');
+      if (id) ids.push(id);
+    });
+    $input.val(ids.join(','));
+  }
+
+  $(document).on('click', '#wp3d-select-pages', function(e){
+    e.preventDefault();
+    var frame = wp.media({
+      title: 'Select Flipbook Images',
+      button: { text: 'Use images' },
+      library: { type: 'image' },
+      multiple: true
+    });
+
+    frame.on('select', function(){
+      var selection = frame.state().get('selection');
+      var $list = $('#wp3d-pages-list');
+      selection.each(function(att){
+        var id = att.get('id');
+        var url = att.get('sizes') && att.get('sizes').thumbnail ? att.get('sizes').thumbnail.url : att.get('url');
+        var $li = $('<li class="wp3d-page-item"/>').attr('data-id', id);
+        $li.append($('<img/>').attr('src', url).attr('alt', ''));
+        $li.append($('<span class="dashicons dashicons-no-alt wp3d-remove" title="Remove"/>'));
+        $list.append($li);
+      });
+      refreshHiddenInput($('#wp3d-pages-list'), $('#wp3d-pages-input'));
+    });
+
+    frame.open();
+  });
+
+  $(document).on('click', '#wp3d-clear-pages', function(e){
+    e.preventDefault();
+    $('#wp3d-pages-list').empty();
+    $('#wp3d-pages-input').val('');
+  });
+
+  $(document).on('click', '.wp3d-remove', function(){
+    $(this).closest('li').remove();
+    refreshHiddenInput($('#wp3d-pages-list'), $('#wp3d-pages-input'));
+  });
+
+  $(function(){
+    $('#wp3d-pages-list').sortable({
+      update: function(){
+        refreshHiddenInput($('#wp3d-pages-list'), $('#wp3d-pages-input'));
+      }
+    });
+  });
+})(jQuery);

--- a/wp-3d-flipbook-lite/assets/public/style.css
+++ b/wp-3d-flipbook-lite/assets/public/style.css
@@ -1,0 +1,28 @@
+/* Public styles for WP 3D Flipbook Lite */
+.wp3d-flipbook {
+	position: relative;
+	width: 100%;
+}
+.wp3d-flipbook .wp3d-toolbar {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	padding: 6px 0;
+}
+.wp3d-flipbook .wp3d-btn {
+	background: #f1f1f1;
+	border: 1px solid #ccc;
+	padding: 6px 10px;
+	cursor: pointer;
+}
+.wp3d-flipbook .wp3d-btn:hover {
+	background: #e7e7e7;
+}
+.wp3d-flipbook .wp3d-canvas {
+	width: 100%;
+	height: auto;
+}
+.wp3d-flipbook canvas {
+	display: block;
+	max-width: 100%;
+}

--- a/wp-3d-flipbook-lite/assets/public/viewer.js
+++ b/wp-3d-flipbook-lite/assets/public/viewer.js
@@ -1,0 +1,125 @@
+(function(){
+  'use strict';
+
+  function initFlipbook(container) {
+    try {
+      var dataScript = container.querySelector('script.wp3d-data');
+      var config = JSON.parse(dataScript.textContent || '{}');
+      var pages = config.pages || [];
+      var width = config.width || 800;
+      var height = config.height || 600;
+      var bg = config.bg || '#ffffff';
+
+      var canvasHost = container.querySelector('.wp3d-canvas');
+      var scene = new THREE.Scene();
+      scene.background = new THREE.Color(bg);
+      var camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 1000);
+      camera.position.set(0, 0, 6);
+
+      var renderer = new THREE.WebGLRenderer({ antialias: true });
+      renderer.setSize(width, height);
+      canvasHost.innerHTML = '';
+      canvasHost.appendChild(renderer.domElement);
+
+      function onResize() {
+        var hostWidth = container.clientWidth;
+        var scale = hostWidth / width;
+        var w = Math.max(200, Math.round(width * scale));
+        var h = Math.max(200, Math.round(height * scale));
+        renderer.setSize(w, h, false);
+        camera.aspect = w / h;
+        camera.updateProjectionMatrix();
+      }
+      window.addEventListener('resize', onResize);
+
+      var loader = new THREE.TextureLoader();
+      var materials = pages.map(function(url){
+        var tex = loader.load(url);
+        tex.colorSpace = THREE.SRGBColorSpace || THREE.LinearSRGBColorSpace; // version-safe
+        return new THREE.MeshBasicMaterial({ map: tex, side: THREE.DoubleSide });
+      });
+
+      var geometry = new THREE.PlaneGeometry(4, 5.2);
+      var leftPage = new THREE.Mesh(geometry, new THREE.MeshBasicMaterial({ color: 0xffffff }));
+      var rightPage = new THREE.Mesh(geometry, materials[0] || new THREE.MeshBasicMaterial({ color: 0xdddddd }));
+      leftPage.position.set(-2.05, 0, 0);
+      rightPage.position.set(2.05, 0, 0);
+
+      scene.add(leftPage);
+      scene.add(rightPage);
+
+      var currentIndex = 0; // index points to right page texture
+
+      function updatePages() {
+        var leftIndex = Math.max(0, currentIndex - 1);
+        if (materials[leftIndex]) leftPage.material = materials[leftIndex];
+        if (materials[currentIndex]) rightPage.material = materials[currentIndex];
+      }
+
+      function animateFlip(next) {
+        var duration = 400; // ms
+        var start = performance.now();
+        var startRotY = next ? 0 : Math.PI;
+        var endRotY = next ? Math.PI : 0;
+
+        var page = new THREE.Mesh(geometry, next ? rightPage.material : leftPage.material);
+        page.position.copy(next ? rightPage.position : leftPage.position);
+        page.rotation.y = startRotY;
+        scene.add(page);
+
+        function step(now) {
+          var t = Math.min(1, (now - start) / duration);
+          var eased = t < 0.5 ? 2*t*t : -1 + (4 - 2*t)*t; // easeInOutQuad
+          page.rotation.y = startRotY + (endRotY - startRotY) * eased;
+          renderer.render(scene, camera);
+          if (t < 1) requestAnimationFrame(step);
+          else {
+            scene.remove(page);
+            renderer.render(scene, camera);
+          }
+        }
+        requestAnimationFrame(step);
+      }
+
+      function goNext() {
+        if (currentIndex < materials.length - 1) {
+          animateFlip(true);
+          currentIndex += 1;
+          updatePages();
+        }
+      }
+      function goPrev() {
+        if (currentIndex > 0) {
+          animateFlip(false);
+          currentIndex -= 1;
+          updatePages();
+        }
+      }
+
+      var prevBtn = container.querySelector('.wp3d-prev');
+      var nextBtn = container.querySelector('.wp3d-next');
+      prevBtn.addEventListener('click', goPrev);
+      nextBtn.addEventListener('click', goNext);
+
+      updatePages();
+      onResize();
+      renderer.setAnimationLoop(function(){
+        renderer.render(scene, camera);
+      });
+
+    } catch (e) {
+      console.error('WP3D Flipbook init failed', e);
+    }
+  }
+
+  function boot() {
+    var nodes = document.querySelectorAll('.wp3d-flipbook');
+    nodes.forEach(initFlipbook);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot);
+  } else {
+    boot();
+  }
+})();

--- a/wp-3d-flipbook-lite/includes/class-flipbook-admin.php
+++ b/wp-3d-flipbook-lite/includes/class-flipbook-admin.php
@@ -1,0 +1,123 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class WP3D_Flipbook_Admin {
+	private static $instance = null;
+	private $meta_key_pages = '_flipbook_pages';
+	private $meta_key_settings = '_flipbook_settings';
+
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	private function __construct() {
+		add_action( 'add_meta_boxes', [ $this, 'add_metaboxes' ] );
+		add_action( 'save_post_flipbook', [ $this, 'save_metabox' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
+	}
+
+	public function add_metaboxes() {
+		add_meta_box(
+			'wp3d_flipbook_pages',
+			__( 'Flipbook Pages', 'wp-3d-flipbook-lite' ),
+			[ $this, 'render_pages_metabox' ],
+			'flipbook',
+			'normal',
+			'high'
+		);
+
+		add_meta_box(
+			'wp3d_flipbook_settings',
+			__( 'Flipbook Settings', 'wp-3d-flipbook-lite' ),
+			[ $this, 'render_settings_metabox' ],
+			'flipbook',
+			'side',
+			'default'
+		);
+	}
+
+	public function render_pages_metabox( $post ) {
+		wp_nonce_field( 'wp3d_flipbook_save', 'wp3d_flipbook_nonce' );
+		$pages = get_post_meta( $post->ID, $this->meta_key_pages, true );
+		if ( ! is_array( $pages ) ) { $pages = []; }
+		?>
+		<div id="wp3d-pages-wrapper">
+			<p>
+				<button type="button" class="button button-primary" id="wp3d-select-pages"><?php esc_html_e( 'Select Images', 'wp-3d-flipbook-lite' ); ?></button>
+				<button type="button" class="button" id="wp3d-clear-pages"><?php esc_html_e( 'Clear', 'wp-3d-flipbook-lite' ); ?></button>
+			</p>
+			<ul id="wp3d-pages-list">
+				<?php foreach ( $pages as $attachment_id ) :
+					$thumb = wp_get_attachment_image_src( $attachment_id, 'thumbnail' );
+					if ( ! $thumb ) { continue; }
+				?>
+				<li class="wp3d-page-item" data-id="<?php echo esc_attr( $attachment_id ); ?>">
+					<img src="<?php echo esc_url( $thumb[0] ); ?>" alt="" />
+					<span class="dashicons dashicons-no-alt wp3d-remove" title="<?php esc_attr_e( 'Remove', 'wp-3d-flipbook-lite' ); ?>"></span>
+				</li>
+				<?php endforeach; ?>
+			</ul>
+			<input type="hidden" id="wp3d-pages-input" name="wp3d_pages" value="<?php echo esc_attr( implode( ',', array_map( 'intval', $pages ) ) ); ?>" />
+			<p class="description"><?php esc_html_e( 'Drag to reorder pages. First item is the front cover.', 'wp-3d-flipbook-lite' ); ?></p>
+		</div>
+		<?php
+	}
+
+	public function render_settings_metabox( $post ) {
+		$settings = get_post_meta( $post->ID, $this->meta_key_settings, true );
+		$width = isset( $settings['width'] ) ? (int) $settings['width'] : 800;
+		$height = isset( $settings['height'] ) ? (int) $settings['height'] : 600;
+		$bg = isset( $settings['bg'] ) ? $settings['bg'] : '#ffffff';
+		?>
+		<p>
+			<label for="wp3d-width" style="display:block;margin-bottom:4px;"><strong><?php esc_html_e( 'Viewer Width (px)', 'wp-3d-flipbook-lite' ); ?></strong></label>
+			<input type="number" id="wp3d-width" name="wp3d_width" min="200" step="10" value="<?php echo esc_attr( $width ); ?>" />
+		</p>
+		<p>
+			<label for="wp3d-height" style="display:block;margin-bottom:4px;"><strong><?php esc_html_e( 'Viewer Height (px)', 'wp-3d-flipbook-lite' ); ?></strong></label>
+			<input type="number" id="wp3d-height" name="wp3d_height" min="200" step="10" value="<?php echo esc_attr( $height ); ?>" />
+		</p>
+		<p>
+			<label for="wp3d-bg" style="display:block;margin-bottom:4px;"><strong><?php esc_html_e( 'Background Color', 'wp-3d-flipbook-lite' ); ?></strong></label>
+			<input type="text" id="wp3d-bg" name="wp3d_bg" class="regular-text" value="<?php echo esc_attr( $bg ); ?>" placeholder="#ffffff" />
+		</p>
+		<?php
+	}
+
+	public function save_metabox( $post_id ) {
+		if ( ! isset( $_POST['wp3d_flipbook_nonce'] ) || ! wp_verify_nonce( $_POST['wp3d_flipbook_nonce'], 'wp3d_flipbook_save' ) ) {
+			return;
+		}
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) { return; }
+		if ( ! current_user_can( 'edit_post', $post_id ) ) { return; }
+
+		// Pages
+		if ( isset( $_POST['wp3d_pages'] ) ) {
+			$ids = array_filter( array_map( 'intval', explode( ',', (string) $_POST['wp3d_pages'] ) ) );
+			update_post_meta( $post_id, $this->meta_key_pages, $ids );
+		}
+
+		// Settings
+		$settings = [
+			'width' => isset( $_POST['wp3d_width'] ) ? max( 200, (int) $_POST['wp3d_width'] ) : 800,
+			'height' => isset( $_POST['wp3d_height'] ) ? max( 200, (int) $_POST['wp3d_height'] ) : 600,
+			'bg' => isset( $_POST['wp3d_bg'] ) ? sanitize_text_field( $_POST['wp3d_bg'] ) : '#ffffff',
+		];
+		update_post_meta( $post_id, $this->meta_key_settings, $settings );
+	}
+
+	public function enqueue_admin_assets( $hook ) {
+		$screen = get_current_screen();
+		if ( ! $screen || 'flipbook' !== $screen->post_type ) {
+			return;
+		}
+
+		wp_enqueue_media();
+		wp_enqueue_style( 'wp3d-admin', WP3D_FLIPBOOK_URL . 'assets/admin/admin.css', [], WP3D_FLIPBOOK_VERSION );
+		wp_enqueue_script( 'jquery-ui-sortable' );
+		wp_enqueue_script( 'wp3d-admin', WP3D_FLIPBOOK_URL . 'assets/admin/admin.js', [ 'jquery', 'jquery-ui-sortable' ], WP3D_FLIPBOOK_VERSION, true );
+	}
+}

--- a/wp-3d-flipbook-lite/includes/class-flipbook-cpt.php
+++ b/wp-3d-flipbook-lite/includes/class-flipbook-cpt.php
@@ -1,0 +1,30 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class WP3D_Flipbook_CPT {
+	public static function register() {
+		$labels = [
+			'name' => __( 'Flipbooks', 'wp-3d-flipbook-lite' ),
+			'singular_name' => __( 'Flipbook', 'wp-3d-flipbook-lite' ),
+			'add_new' => __( 'Add New', 'wp-3d-flipbook-lite' ),
+			'add_new_item' => __( 'Add New Flipbook', 'wp-3d-flipbook-lite' ),
+			'edit_item' => __( 'Edit Flipbook', 'wp-3d-flipbook-lite' ),
+			'new_item' => __( 'New Flipbook', 'wp-3d-flipbook-lite' ),
+			'view_item' => __( 'View Flipbook', 'wp-3d-flipbook-lite' ),
+			'view_items' => __( 'View Flipbooks', 'wp-3d-flipbook-lite' ),
+			'not_found' => __( 'No flipbooks found', 'wp-3d-flipbook-lite' ),
+			'all_items' => __( 'Flipbooks', 'wp-3d-flipbook-lite' ),
+		];
+
+		$args = [
+			'labels' => $labels,
+			'public' => false,
+			'show_ui' => true,
+			'show_in_menu' => true,
+			'menu_icon' => 'dashicons-book-alt',
+			'supports' => [ 'title' ],
+		];
+
+		register_post_type( 'flipbook', $args );
+	}
+}

--- a/wp-3d-flipbook-lite/includes/class-flipbook-shortcode.php
+++ b/wp-3d-flipbook-lite/includes/class-flipbook-shortcode.php
@@ -1,0 +1,79 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class WP3D_Flipbook_Shortcode {
+	private static $instance = null;
+	private $meta_key_pages = '_flipbook_pages';
+	private $meta_key_settings = '_flipbook_settings';
+	private $did_enqueue = false;
+	private $instance_counter = 0;
+
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	private function __construct() {
+		add_shortcode( 'flipbook', [ $this, 'render_shortcode' ] );
+	}
+
+	private function enqueue_public_assets() {
+		if ( $this->did_enqueue ) { return; }
+
+		wp_register_style( 'wp3d-public', WP3D_FLIPBOOK_URL . 'assets/public/style.css', [], WP3D_FLIPBOOK_VERSION );
+		wp_enqueue_style( 'wp3d-public' );
+
+		// Three.js via CDN
+		wp_register_script( 'three-js', 'https://unpkg.com/three@0.156.1/build/three.min.js', [], '0.156.1', true );
+		wp_register_script( 'wp3d-viewer', WP3D_FLIPBOOK_URL . 'assets/public/viewer.js', [ 'three-js' ], WP3D_FLIPBOOK_VERSION, true );
+		wp_enqueue_script( 'wp3d-viewer' );
+
+		$this->did_enqueue = true;
+	}
+
+	public function render_shortcode( $atts ) {
+		$atts = shortcode_atts( [ 'id' => 0 ], $atts, 'flipbook' );
+		$post_id = (int) $atts['id'];
+		if ( ! $post_id ) { return ''; }
+		$pages = get_post_meta( $post_id, $this->meta_key_pages, true );
+		$settings = get_post_meta( $post_id, $this->meta_key_settings, true );
+		if ( ! is_array( $pages ) || empty( $pages ) ) { return ''; }
+		$width = isset( $settings['width'] ) ? (int) $settings['width'] : 800;
+		$height = isset( $settings['height'] ) ? (int) $settings['height'] : 600;
+		$bg = isset( $settings['bg'] ) ? $settings['bg'] : '#ffffff';
+
+		$image_urls = [];
+		foreach ( $pages as $attachment_id ) {
+			$url = wp_get_attachment_image_src( $attachment_id, 'full' );
+			if ( $url ) { $image_urls[] = esc_url_raw( $url[0] ); }
+		}
+		if ( empty( $image_urls ) ) { return ''; }
+
+		$this->enqueue_public_assets();
+		$this->instance_counter++;
+		$container_id = 'wp3d-flipbook-' . $this->instance_counter . '-' . $post_id;
+
+		$data = [
+			'id' => $container_id,
+			'pages' => $image_urls,
+			'width' => $width,
+			'height' => $height,
+			'bg' => $bg,
+		];
+
+		ob_start();
+		?>
+		<div id="<?php echo esc_attr( $container_id ); ?>" class="wp3d-flipbook" style="max-width:100%;">
+			<div class="wp3d-toolbar">
+				<button class="wp3d-btn wp3d-prev" type="button" aria-label="<?php esc_attr_e( 'Previous', 'wp-3d-flipbook-lite' ); ?>">&#9664;</button>
+				<button class="wp3d-btn wp3d-next" type="button" aria-label="<?php esc_attr_e( 'Next', 'wp-3d-flipbook-lite' ); ?>">&#9654;</button>
+			</div>
+			<div class="wp3d-canvas"></div>
+			<script type="application/json" class="wp3d-data"><?php echo wp_json_encode( $data ); ?></script>
+		</div>
+		<?php
+		return ob_get_clean();
+	}
+}

--- a/wp-3d-flipbook-lite/readme.txt
+++ b/wp-3d-flipbook-lite/readme.txt
@@ -1,0 +1,55 @@
+=== WP 3D Flipbook Lite ===
+Contributors: yourname
+Tags: flipbook, 3D, threejs, viewer, images
+Requires at least: 5.6
+Tested up to: 6.6
+Requires PHP: 7.4
+Stable tag: 0.1.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+A lightweight 3D flipbook plugin powered by Three.js. Create flipbooks from images and embed via shortcode.
+
+== Description ==
+
+WP 3D Flipbook Lite lets you create simple 3D page flip experiences from a set of images. It uses Three.js to render a basic flip animation and provides a minimal toolbar with previous/next controls.
+
+Features:
+- Custom post type `Flipbook`
+- Drag-and-drop ordering of image pages
+- Shortcode to embed anywhere: `[flipbook id="123"]`
+- Responsive sizing (scales to container width)
+
+This is a lightweight starting point intended for small catalogs, brochures, and simple presentations.
+
+== Installation ==
+
+1. Upload the `wp-3d-flipbook-lite` folder to the `/wp-content/plugins/` directory, or install via the WordPress Plugins screen.
+2. Activate the plugin through the 'Plugins' screen in WordPress.
+3. Go to `Flipbooks` > `Add New`.
+4. Use the "Select Images" button to choose pages from the media library and drag to reorder.
+5. Adjust viewer settings (width, height, background color) and publish.
+6. Copy the shortcode from the published flipbook and paste it into any post or page: `[flipbook id="123"]` (replace 123 with your flipbook post ID).
+
+== Frequently Asked Questions ==
+
+= How do I change the size? =
+Use the settings metabox on the flipbook edit screen to set width and height in pixels. The viewer will scale to fit its container on the front-end.
+
+= Does it support PDFs? =
+This lite version supports images. Convert your PDF pages to images before creating a flipbook.
+
+= Can I use Gutenberg/Block Editor? =
+Yes. Insert a Shortcode block and paste `[flipbook id="123"]`.
+
+== Screenshots ==
+1. Admin metabox for selecting and ordering pages
+2. Front-end viewer with basic toolbar
+
+== Changelog ==
+= 0.1.0 =
+- Initial release with CPT, admin UI, shortcode, and basic Three.js viewer
+
+== Upgrade Notice ==
+= 0.1.0 =
+Initial release.

--- a/wp-3d-flipbook-lite/wp-3d-flipbook-lite.php
+++ b/wp-3d-flipbook-lite/wp-3d-flipbook-lite.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Plugin Name: WP 3D Flipbook Lite
+ * Description: A lightweight 3D flipbook plugin powered by Three.js. Create flipbooks from images and embed via shortcode.
+ * Version: 0.1.0
+ * Author: Your Name
+ * License: GPLv2 or later
+ * Text Domain: wp-3d-flipbook-lite
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+define( 'WP3D_FLIPBOOK_VERSION', '0.1.0' );
+define( 'WP3D_FLIPBOOK_FILE', __FILE__ );
+define( 'WP3D_FLIPBOOK_DIR', plugin_dir_path( __FILE__ ) );
+define( 'WP3D_FLIPBOOK_URL', plugin_dir_url( __FILE__ ) );
+
+// Includes
+require_once WP3D_FLIPBOOK_DIR . 'includes/class-flipbook-cpt.php';
+require_once WP3D_FLIPBOOK_DIR . 'includes/class-flipbook-admin.php';
+require_once WP3D_FLIPBOOK_DIR . 'includes/class-flipbook-shortcode.php';
+
+// Bootstrap
+add_action( 'init', [ 'WP3D_Flipbook_CPT', 'register' ] );
+
+add_action( 'plugins_loaded', function() {
+	// Admin features
+	if ( is_admin() ) {
+		WP3D_Flipbook_Admin::get_instance();
+	}
+
+	// Front-end shortcode
+	WP3D_Flipbook_Shortcode::get_instance();
+} );


### PR DESCRIPTION
Create a lightweight WordPress 3D flipbook plugin to enable a basic page-flipping experience from images.

This plugin introduces a `Flipbook` custom post type, an admin interface for selecting and ordering image pages, and a `[flipbook id=""]` shortcode to embed a Three.js-powered viewer on the front-end.

---
<a href="https://cursor.com/background-agent?bcId=bc-b454b55d-0d7b-4a13-8b90-4e7409a9e754">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b454b55d-0d7b-4a13-8b90-4e7409a9e754">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

